### PR TITLE
fix: 空タグがあると内部エラーになるのを修正 

### DIFF
--- a/Model/Tag.php
+++ b/Model/Tag.php
@@ -159,6 +159,11 @@ class Tag extends TagsAppModel {
 				$tagNameList[] = $tag['name'];
 			}
 		}
+
+		// trimして空のタグを除去
+		$tagNameList = array_map('trim', $tagNameList);
+		$tagNameList = array_filter($tagNameList);
+
 		foreach ($tagNameList as $tagName) {
 			//
 			$savedTag = $this->findByBlockIdAndModelAndName($blockId, $modelName, $tagName);


### PR DESCRIPTION
空文字列タグを入力してブログ記事を投稿すると内部エラーになってたのを修正しました。